### PR TITLE
feat: support structured lyrics

### DIFF
--- a/scripts/simple-parser.js
+++ b/scripts/simple-parser.js
@@ -269,7 +269,11 @@ async function main() {
     console.log(result.lyrics);
     console.log('─'.repeat(50));
     console.log('');
-    console.log(`📊 共 ${result.lyrics.split('\n').length} 行歌词`);
+    if (typeof result.lyrics === 'string') {
+      console.log(`📊 共 ${result.lyrics.split('\n').length} 行歌词`);
+    } else if (result.lyrics?.sentences) {
+      console.log(`📊 共 ${result.lyrics.sentences.length} 行歌词`);
+    }
   } else {
     console.log('❌ 解析失败！');
     console.log(`错误信息: ${result.error}`);

--- a/src/components/LyricsDisplay.vue
+++ b/src/components/LyricsDisplay.vue
@@ -28,16 +28,16 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { ParseResult, DisplayFormat, DownloadFormat } from '../types/lyrics'
+  import type { ParseResult, DisplayFormat, DownloadFormat, LyricsData } from '../types/lyrics'
 import { useLyricsFormatter } from '../composables/useLyricsFormatter'
 import { useFileDownload } from '../composables/useFileDownload'
 
 interface Props {
-  result: ParseResult
-  lyrics: string
+    result: ParseResult
+    lyrics: string | LyricsData
 }
 
-const props = defineProps<Props>()
+  const props = defineProps<Props>()
 
 const displayFormat = ref<DisplayFormat>('plain')
 const downloadFormat = ref<DownloadFormat>('srt')

--- a/src/composables/useFileDownload.ts
+++ b/src/composables/useFileDownload.ts
@@ -8,19 +8,19 @@ export const useFileDownload = () => {
   /**
    * 获取歌词数据（统一处理函数）
    */
-  const getLyricsData = (result: ParseResult) => {
-    // 优先使用 lyrics_with_timing
-    if (result?.lyrics_with_timing && Array.isArray(result.lyrics_with_timing)) {
-      return result.lyrics_with_timing
+    const getLyricsData = (result: ParseResult) => {
+      // 优先使用 lyrics_with_timing
+      if (result?.lyrics_with_timing && Array.isArray(result.lyrics_with_timing)) {
+        return result.lyrics_with_timing
+      }
+
+      // 如果没有，使用原始歌词数据
+      if (typeof result?.lyrics === 'object' && Array.isArray(result.lyrics.sentences)) {
+        return result.lyrics.sentences.filter((line: any) => line.text && line.text.trim())
+      }
+
+      return []
     }
-    
-    // 如果没有，使用原始歌词数据
-    if (result?.lyrics?.sentences && Array.isArray(result.lyrics.sentences)) {
-      return result.lyrics.sentences.filter((line: any) => line.text && line.text.trim())
-    }
-    
-    return []
-  }
 
   /**
    * 生成 SRT 格式内容
@@ -80,7 +80,7 @@ export const useFileDownload = () => {
     const jsonData = {
       song_info: result.song_info,
       lyrics: {
-        plain_text: result.lyrics,
+        plain_text: typeof result.lyrics === 'string' ? result.lyrics : '',
         with_timing: lyricsData.length > 0 ? lyricsData : result.lyrics_with_timing,
         raw_data: result.lyrics // 保留原始数据结构
       },

--- a/src/composables/useLyricsFormatter.ts
+++ b/src/composables/useLyricsFormatter.ts
@@ -19,9 +19,9 @@ export const useLyricsFormatter = () => {
         .join('\n')
     }
     
-    // 如果没有 lyrics_with_timing，尝试从原始歌词数据中获取
-    if (result?.lyrics?.sentences && Array.isArray(result.lyrics.sentences)) {
-      const filteredSentences = result.lyrics.sentences.filter((line: any) => line.text && line.text.trim())
+      // 如果没有 lyrics_with_timing，尝试从原始歌词数据中获取
+      if (typeof result?.lyrics === 'object' && Array.isArray(result.lyrics.sentences)) {
+        const filteredSentences = result.lyrics.sentences.filter((line: any) => line.text && line.text.trim())
       
       return filteredSentences
         .map((line: any) => {
@@ -38,9 +38,13 @@ export const useLyricsFormatter = () => {
   /**
    * 获取纯文本歌词
    */
-  const getPlainLyrics = (result: ParseResult): string => {
-    return result?.lyrics || ''
-  }
+    const getPlainLyrics = (result: ParseResult): string => {
+      if (!result?.lyrics) return ''
+      if (typeof result.lyrics === 'string') {
+        return result.lyrics
+      }
+      return result.lyrics.sentences?.map((line: any) => line.text).join('\n') || ''
+    }
 
   /**
    * 根据显示格式获取歌词内容

--- a/src/types/lyrics.ts
+++ b/src/types/lyrics.ts
@@ -56,7 +56,10 @@ export interface LyricsData {
 // 解析结果类型
 export interface ParseResult {
   success: boolean
-  lyrics?: string
+  /**
+   * 原始歌词数据，可能是纯文本或结构化格式
+   */
+  lyrics?: string | LyricsData
   lyrics_with_timing?: LyricsLine[]
   song_info?: SongInfo
   source?: string


### PR DESCRIPTION
## Summary
- allow `ParseResult.lyrics` to be either plain text or structured data
- handle both lyric forms when formatting and exporting
- type updates in lyrics display and simple parser

## Testing
- `npx vue-tsc --noEmit` *(fails: 403 Forbidden retrieving vue-tsc package)*

------
https://chatgpt.com/codex/tasks/task_e_68a58f14e078832c9abf9ebaa5a6d6a1